### PR TITLE
Update to Crystal 0.16.0

### DIFF
--- a/src/processor.cr
+++ b/src/processor.cr
@@ -4,7 +4,7 @@ include Crystal
 
 class MyVisitor < Visitor
   def initialize(name)
-    @str = StringIO.new
+    @str = MemoryIO.new
     @str << %(redefine_main("Init_#{name}") { |main| {{main}} }\n)
   end
 
@@ -13,7 +13,7 @@ class MyVisitor < Visitor
   end
 
   def visit(node : Def)
-    @str << %(_class.def "#{node.name}", #{node.args.length}, )
+    @str << %(_class.def "#{node.name}", #{node.args.size}, )
     @str << %[->(self : LibRuby::VALUE, ]
     node.args.each do |arg|
       @str << %(_#{arg.name} : LibRuby::VALUE, )

--- a/src/ruby.cr
+++ b/src/ruby.cr
@@ -1,4 +1,4 @@
-require "lib_ruby"
+require "./lib_ruby"
 
 struct Nil
   def to_ruby
@@ -32,8 +32,6 @@ module Ruby
   end
 
   struct Value
-    @value :: LibRuby::VALUE
-
     def initialize(@value : LibRuby::VALUE)
     end
 
@@ -54,5 +52,5 @@ module Ruby
 end
 
 macro ruby_extension(name, code)
-  {{ run "processor", name, code }}
+  {{ run "./processor", name, code }}
 end


### PR DESCRIPTION
While trying to write a simple extension for Ruby with Crystal i've seen that this no longer works with Crystal 0.16.0. So i updated.

There's a problem though.

```
➜  crystal_ruby git:(master) ✗ make irb
irb -rtest_ruby -I.
2.3.0 :001 > Foo.new.foo 3
 => "From Crystal!! \#{a}"
```

As you can easily see the `a` variable is being escaped.
